### PR TITLE
Release 17.0.4 snapshot

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,9 +8,16 @@ AM_CFLAGS = $(DEFINES) \
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libwayland-egl.la
-
+noinst_HEADERS = wayland-egl-priv.h
 libwayland_egl_la_SOURCES = wayland-egl.c
-libwayland_egl_la_LDFLAGS = -version-info 1
+libwayland_egl_la_LDFLAGS = \
+	-no-undefined \
+	-version-info 1 \
+	$(GC_SECTIONS) \
+	$(LD_NO_UNDEFINED)
+
+TESTS = wayland-egl-symbols-check
+EXTRA_DIST = wayland-egl-symbols-check
 
 libwayland_egl_la_CFLAGS = \
 	@WAYLAND_CLIENT_CFLAGS@

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,11 @@
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = wayland-egl.pc
+
 AM_CFLAGS = $(DEFINES) \
 	    $(VISIBILITY_CFLAGS) \
 	    $(WAYLAND_CFLAGS)
+
+ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libwayland-egl.la
 
@@ -12,10 +17,3 @@ libwayland_egl_la_CFLAGS = \
 
 libwayland_egl_la_LIBADD = \
 	@WAYLAND_CLIENT_LIBS@
-
-extdir = $(includedir)
-ext_HEADERS = wayland-egl-priv.h
-
-pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = wayland-egl.pc
-

--- a/configure.ac
+++ b/configure.ac
@@ -21,15 +21,16 @@
 #
 
 # Initialize Autoconf
-AC_PREREQ([2.60])
-AC_INIT([libwayland-egl], [9.3.0],
-        [https://bugs.freedesktop.org/enter_bug.cgi?product=Mesa], [libwayland-egl])
+AC_PREREQ([2.69])
+AC_INIT([libwayland-egl], [17.0.4],
+        [https://bugs.freedesktop.org/enter_bug.cgi?product=Mesa])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_HEADERS([config.h])
 
 # Initialize Automake
 AM_INIT_AUTOMAKE([foreign dist-bzip2])
 #AM_MAINTAINER_MODE
+AC_CONFIG_MACRO_DIRS([m4])
 
 # Initialize libtool
 AC_PROG_LIBTOOL
@@ -38,4 +39,11 @@ AC_PROG_LIBTOOL
 PKG_CHECK_MODULES([WAYLAND_CLIENT], [wayland-client])
 
 AC_CONFIG_FILES([Makefile wayland-egl.pc])
+
+# Checks for library functions.
+AC_FUNC_MALLOC
+
+## Suggested by libtoolize
+LT_INIT
+
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,21 @@ AC_CONFIG_FILES([Makefile wayland-egl.pc])
 # Checks for library functions.
 AC_FUNC_MALLOC
 
+dnl
+dnl Check if linker supports garbage collection
+dnl
+save_LDFLAGS=$LDFLAGS
+LDFLAGS="$LDFLAGS -Wl,--gc-sections"
+AC_MSG_CHECKING([whether ld supports --gc-sections])
+AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([static char UnusedFunc() { return 5; } int main() { return 0;}])],
+    [AC_MSG_RESULT([yes])
+        GC_SECTIONS="-Wl,--gc-sections";],
+    [AC_MSG_RESULT([no])
+        GC_SECTIONS="";])
+LDFLAGS=$save_LDFLAGS
+
 ## Suggested by libtoolize
-LT_INIT
+LT_INIT([disable-static])
 
 AC_OUTPUT

--- a/wayland-egl-priv.h
+++ b/wayland-egl-priv.h
@@ -1,18 +1,45 @@
+/*
+ * Copyright © 2011 Benjamin Franzke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Benjamin Franzke <benjaminfranzke@googlemail.com>
+ */
+
 #ifndef _WAYLAND_EGL_PRIV_H
 #define _WAYLAND_EGL_PRIV_H
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
 /* GCC visibility */
-#if defined(__GNUC__) && __GNUC__ >= 4
+#if defined(__GNUC__)
 #define WL_EGL_EXPORT __attribute__ ((visibility("default")))
 #else
 #define WL_EGL_EXPORT
 #endif
 
 #include <wayland-client.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
 
 struct wl_egl_window {
 	struct wl_surface *surface;
@@ -27,6 +54,7 @@ struct wl_egl_window {
 
 	void *private;
 	void (*resize_callback)(struct wl_egl_window *, void *);
+	void (*destroy_window_callback)(void *);
 };
 
 #ifdef  __cplusplus

--- a/wayland-egl-symbols-check
+++ b/wayland-egl-symbols-check
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+FUNCS=$(nm -D --defined-only ${1-.libs/libwayland-egl.so} | grep -o "T .*" | cut -c 3- | while read func; do
+( grep -q "^$func$" || echo $func )  <<EOF
+wl_egl_window_resize
+wl_egl_window_create
+wl_egl_window_destroy
+wl_egl_window_get_attached_size
+_fini
+_init
+EOF
+done)
+
+test ! -n "$FUNCS" || echo $FUNCS
+test ! -n "$FUNCS"
+

--- a/wayland-egl.c
+++ b/wayland-egl.c
@@ -1,3 +1,32 @@
+/*
+ * Copyright © 2011 Kristian Høgsberg
+ * Copyright © 2011 Benjamin Franzke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Kristian Høgsberg <krh@bitplanet.net>
+ *    Benjamin Franzke <benjaminfranzke@googlemail.com>
+ */
+
 #include <stdlib.h>
 
 #include <wayland-client.h>
@@ -9,6 +38,9 @@ wl_egl_window_resize(struct wl_egl_window *egl_window,
 		     int width, int height,
 		     int dx, int dy)
 {
+	if (width <= 0 || height <= 0)
+		return;
+
 	egl_window->width  = width;
 	egl_window->height = height;
 	egl_window->dx     = dx;
@@ -24,6 +56,9 @@ wl_egl_window_create(struct wl_surface *surface,
 {
 	struct wl_egl_window *egl_window;
 
+	if (width <= 0 || height <= 0)
+		return NULL;
+
 	egl_window = malloc(sizeof *egl_window);
 	if (!egl_window)
 		return NULL;
@@ -31,6 +66,7 @@ wl_egl_window_create(struct wl_surface *surface,
 	egl_window->surface = surface;
 	egl_window->private = NULL;
 	egl_window->resize_callback = NULL;
+	egl_window->destroy_window_callback = NULL;
 	wl_egl_window_resize(egl_window, width, height, 0, 0);
 	egl_window->attached_width  = 0;
 	egl_window->attached_height = 0;
@@ -41,6 +77,8 @@ wl_egl_window_create(struct wl_surface *surface,
 WL_EGL_EXPORT void
 wl_egl_window_destroy(struct wl_egl_window *egl_window)
 {
+	if (egl_window->destroy_window_callback)
+		egl_window->destroy_window_callback(egl_window->private);
 	free(egl_window);
 }
 

--- a/wayland-egl.pc.in
+++ b/wayland-egl.pc.in
@@ -6,5 +6,6 @@ includedir=@includedir@
 Name: wayland-egl
 Description: Mesa wayland-egl library
 Version: @VERSION@
+Requires: wayland-client
 Libs: -L${libdir} -lwayland-egl
 Cflags: -I${includedir}


### PR DESCRIPTION
This upgrades wayland-egl to mesa 17.0.4, including ability to run make check (1 test)